### PR TITLE
Improve version compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'fabric-loom' version '0.10-SNAPSHOT'
-  id 'maven-publish'
+    id 'fabric-loom' version '1.0-SNAPSHOT'
+    id 'maven-publish'
 }
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -11,63 +11,67 @@ version = "${project.mod_version}+${project.minecraft_version}"
 group = project.maven_group
 
 repositories {
-  maven { url = "https://maven.nucleoid.xyz/" }
+    maven { url = "https://maven.nucleoid.xyz/" }
+    maven { url = "https://jitpack.io" }
 }
 
 dependencies {
-  minecraft "com.mojang:minecraft:${project.minecraft_version}"
-  mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-  modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+    implementation(include("com.github.LlamaLad7:MixinExtras:${project.mixinextras_version}"))
+    annotationProcessor("com.github.LlamaLad7:MixinExtras:${project.mixinextras_version}")
 }
 
 processResources {
-  inputs.property "version", project.version
+    inputs.property "version", project.version
 
-  filesMatching("fabric.mod.json") {
-    expand "version": project.version
-  }
+    filesMatching("fabric.mod.json") {
+        expand "version": project.version
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {
-  it.options.encoding = "UTF-8"
-  it.options.release = 17
+    it.options.encoding = "UTF-8"
+    it.options.release = 17
 }
 
 java {
-  withSourcesJar()
+    withSourcesJar()
 }
 
 jar {
-  from("LICENSE") {
-    rename { "${it}_${project.archivesBaseName}"}
-  }
+    from("LICENSE") {
+        rename { "${it}_${project.archivesBaseName}" }
+    }
 }
 
 def env = System.getenv()
 
 publishing {
-  publications {
-    mavenJava(MavenPublication) {
-      artifact(remapJar) {
-        builtBy remapJar
-      }
-      artifact(sourcesJar) {
-        builtBy remapSourcesJar
-      }
-    }
-  }
-
-  repositories {
-    if (env.MAVEN_URL) {
-      maven {
-        credentials {
-          username env.MAVEN_USERNAME
-          password env.MAVEN_PASSWORD
+    publications {
+        mavenJava(MavenPublication) {
+            artifact(remapJar) {
+                builtBy remapJar
+            }
+            artifact(sourcesJar) {
+                builtBy remapSourcesJar
+            }
         }
-        url env.MAVEN_URL
-      }
-    } else {
-      mavenLocal()
     }
-  }
+
+    repositories {
+        if (env.MAVEN_URL) {
+            maven {
+                credentials {
+                    username env.MAVEN_USERNAME
+                    password env.MAVEN_PASSWORD
+                }
+                url env.MAVEN_URL
+            }
+        } else {
+            mavenLocal()
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.1
-loader_version=0.13.3
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.5
+loader_version=0.14.13
 
 # Mod Properties
 mod_version=0.3.0
 maven_group=xyz.nucleoid
 archives_base_name=packet-tweaker
+
+mixinextras_version=0.2.0-beta.1

--- a/src/main/java/xyz/nucleoid/packettweaker/mixin/ServerNetworkIoAcceptorMixin.java
+++ b/src/main/java/xyz/nucleoid/packettweaker/mixin/ServerNetworkIoAcceptorMixin.java
@@ -1,6 +1,8 @@
 package xyz.nucleoid.packettweaker.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
 import net.minecraft.network.ClientConnection;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,10 +15,12 @@ import xyz.nucleoid.packettweaker.ConnectionHolder;
 public class ServerNetworkIoAcceptorMixin {
     @Inject(
             method = "initChannel(Lio/netty/channel/Channel;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;setPacketListener(Lnet/minecraft/network/listener/PacketListener;)V"),
-            locals = LocalCapture.CAPTURE_FAILHARD
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/ClientConnection;setPacketListener(Lnet/minecraft/network/listener/PacketListener;)V"
+            )
     )
-    private void packetTweaker_initChannel(Channel channel, CallbackInfo ci, int rateLimit, ClientConnection connection) {
+    private void packetTweaker_initChannel(Channel channel, CallbackInfo ci, @Local ClientConnection connection) {
         ConnectionHolder encoder = (ConnectionHolder) channel.pipeline().get("encoder");
         encoder.setConnection(connection);
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,7 +8,9 @@
   "license": "LGPLv3",
   "environment": "*",
   "entrypoints": {
-    "main": []
+    "preLaunch": [
+      "com.llamalad7.mixinextras.MixinExtrasBootstrap::init"
+    ]
   },
   "mixins": ["packettweaker.mixins.json"],
   "custom": {


### PR DESCRIPTION
In 23w03a the LVT of `initChannel` changed from `I, Lnet/minecraft/network/Connection;` to`Lio/netty/channel/ChannelPipeline;, I, Lnet/minecraft/network/Connection;`
This PR adds [MixinExtras](https://github.com/LlamaLad7/MixinExtras/) and uses it to access the required local variable, without caring about the rest of the LVT!